### PR TITLE
Prefix check for containedBy, so that autoscaling group machines are matched

### DIFF
--- a/lib/match.js
+++ b/lib/match.js
@@ -56,7 +56,9 @@ function build(system) {
 
     _.each(anCompareList, function(an) {
       var sys = _.find(sysCompareList, function(sys) {
-        return sys.containedBy === an.containedBy && sys.containerDefinitionId === an.containerDefinitionId;
+        // we need to check for prefix to support autoscaling groups
+        return an.containedBy.indexOf(sys.containedBy) >= 0 &&
+          sys.containerDefinitionId === an.containerDefinitionId;
       });
       if (sys) {
         if (an.id !== sys.id && analyzed.topology.containers[an.id]) {


### PR DESCRIPTION
Part of https://github.com/nearform/nscale-kernel/pull/101

@Nss @pelger please review :).